### PR TITLE
`TASK-3428` 소유권 없는 yarn 파일 점검

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 RUN npm install -g serve pxt
 
+# CSAP-U07 소유자가 존재하지 않는 파일 제거
+RUN chown -R root:root /opt/yarn-v*
+
 # install app dependencies
 COPY package.json package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
CSAP 취약점 점검에서 yarn 파일들이 소유권이 없던 문제를 해결합니다. 오래된 yarn v1 패키지를 사용해서 발생하는 문제이므로 업스트립 이슈이며, chown을 통해 해결했습니다.