### PR TITLE
TASK-3952 테라폼 이전

### DIFF
--- a/.github/workflows/build-microbit-dev.yml
+++ b/.github/workflows/build-microbit-dev.yml
@@ -7,15 +7,22 @@ on:
 jobs:
 
   build:
-    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build.yml@main
+    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build_v2.yml@main
     with:
       env: dev
       target: develop
-      awsImageName: jce-ecr-pxt-microbit-all-dev
-      awsValueFilePath: makecode/dev.yaml
-      ncpRegistry: ped-cr-all-dev.ncr.gov-ntruss.com
-      ncpImageName: jce-pxt-microbit
-      ncpValueFilePath: makecode/ncloud.yaml
+      updateTargets: |
+        {
+          "aws": {
+            "imageName": "jce-ecr-pxt-microbit-all-dev",
+            "valueFilePath": ["makecode/dev.yaml"]
+          },
+          "ncp": {
+            "registry": "ped-cr-all-dev.ncr.gov-ntruss.com",
+            "imageName": "jce-pxt-microbit",
+            "valueFilePath": ["makecode/ncloud.yaml"]
+          }
+        }
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-microbit-prd.yml
+++ b/.github/workflows/build-microbit-prd.yml
@@ -7,15 +7,22 @@ on:
 jobs:
 
   build:
-    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build.yml@main
+    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build_v2.yml@main
     with:
       env: prd
       target: main
-      awsImageName: jce-ecr-pxt-microbit-all-prd
-      awsValueFilePath: makecode/prd.yaml
-      ncpRegistry: ped-cr-all-prd.ncr.gov-ntruss.com
-      ncpImageName: jce-pxt-microbit
-      ncpValueFilePath: makecode/ncloud-prd.yaml
+      updateTargets: |
+        {
+          "aws": {
+            "imageName": "jce-ecr-pxt-microbit-all-prd",
+            "valueFilePath": ["makecode/prd.yaml", "makecode/aws-apne2-prd.yaml"]
+          },
+          "ncp": {
+            "registry": "ped-cr-all-prd.ncr.gov-ntruss.com",
+            "imageName": "jce-pxt-microbit",
+            "valueFilePath": ["makecode/ncloud-prd.yaml"]
+          }
+        }
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
테라폼 이전을 위해 Build GHA에 apne2 목표를 추가하고, 다중 목표를 지원하는 build_v2.yml 로 최신화합니다.