### PR TITLE
chore: remove AWS access key secrets

### DIFF
--- a/.github/workflows/build-microbit-dev.yml
+++ b/.github/workflows/build-microbit-dev.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   build:
-    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build_v2.yml@main
+    uses: team-monolith-product/tmn-gh-actions/.github/workflows/build_v2.yml@develop
     with:
       env: dev
       target: develop
@@ -24,8 +24,6 @@ jobs:
           }
         }
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       NCP_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY_ID }}
       NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
       MACHINE_TOKEN: ${{ secrets.MACHINE_TOKEN }}

--- a/.github/workflows/build-microbit-prd.yml
+++ b/.github/workflows/build-microbit-prd.yml
@@ -24,8 +24,6 @@ jobs:
           }
         }
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       NCP_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY_ID }}
       NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
       MACHINE_TOKEN: ${{ secrets.MACHINE_TOKEN }}


### PR DESCRIPTION
## Summary
- AWS 인증 방식을 access key에서 OIDC role assume 방식으로 변경
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` secrets 제거

## Changes
- `.github/workflows/build-microbit-dev.yml`
- `.github/workflows/build-microbit-prd.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)