### PR TITLE
chore: pxt 버전업 (GitHub API 라우팅 변경)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "pxt-common-packages": "12.0.1",
-                "pxt-core": "npm:@team-monolith/pxt-core@^0.2.2"
+                "pxt-core": "npm:@team-monolith/pxt-core@^0.2.3"
             },
             "devDependencies": {
                 "@types/dom-mediacapture-record": "^1.0.16",
@@ -6126,9 +6126,9 @@
         },
         "node_modules/pxt-core": {
             "name": "@team-monolith/pxt-core",
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@team-monolith/pxt-core/-/pxt-core-0.2.2.tgz",
-            "integrity": "sha512-PnxfgZ7yxsNpMqyoE+BrswMGPFG54OiTHmV0NR0CM61MHjfqSWaAQLzexyYklX+yCgvWf/xNpZDJ2o8FnS7UNg==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@team-monolith/pxt-core/-/pxt-core-0.2.3.tgz",
+            "integrity": "sha512-GHbsxYoPE60Q8j9m42OituNj8Sej5UyV4LFiwpbG3HAJ7uG/v/mlqheyj9P0YA9j3ocwBVZtYtoC3rKEeA8nZw==",
             "hasInstallScript": true,
             "dependencies": {
                 "@blockly/keyboard-navigation": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.0.1",
-        "pxt-core": "npm:@team-monolith/pxt-core@^0.2.2"
+        "pxt-core": "npm:@team-monolith/pxt-core@^0.2.3"
     }
 }


### PR DESCRIPTION
## Summary
- pxt 버전업 (GitHub API 라우팅 변경 포함)
- https://github.com/team-monolith-product/pxt/pull/7

## Changes
- pxt 패키지 버전 업데이트

## Test plan
- [x] 빌드 정상 동작 확인
- [x] Extensions 탭에서 GitHub 패키지 검색/설치 테스트