### PR TITLE
TASK-5524 pxt-core 0.5.0 버전 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "pxt-common-packages": "12.0.1",
-                "pxt-core": "npm:@team-monolith/pxt-core@^0.4.0"
+                "pxt-core": "npm:@team-monolith/pxt-core@^0.5.0"
             },
             "devDependencies": {
                 "@types/dom-mediacapture-record": "^1.0.16",
@@ -6384,9 +6384,9 @@
         },
         "node_modules/pxt-core": {
             "name": "@team-monolith/pxt-core",
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@team-monolith/pxt-core/-/pxt-core-0.4.0.tgz",
-            "integrity": "sha512-YVZQPINIIEAFpAE/H0FzpT0AhzEpgCMifoQVpSbGfPBbOZdLQV2sCCIJlQXiFpMo/vKnGzaTXBKAFqgxkbfatA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@team-monolith/pxt-core/-/pxt-core-0.5.0.tgz",
+            "integrity": "sha512-r3EDDLsWG21ccTkRaf//+7yKIkFjwO/5COHqapGdBtbvIrWaG5Aq5igdiPnZyreIRzkB3S5m58QXd4el7Jjbiw==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.0.1",
-        "pxt-core": "npm:@team-monolith/pxt-core@^0.4.0"
+        "pxt-core": "npm:@team-monolith/pxt-core@^0.5.0"
     }
 }


### PR DESCRIPTION
## Summary
- pxt-core를 0.5.0으로 업데이트하여 `hideExtensionMenu` 옵션 지원
- jce-codle-react PR #2027 (VF 확장킷 제한) 배포 종속성 해소

## Test plan
- [ ] 개발환경에서 VF MakeCode 활동 진입 시 확장킷(Extensions) 메뉴가 숨겨지는지 확인
- [ ] hideExtensionMenu 미설정 시 기존처럼 메뉴가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)