### PR TITLE
fix: nginx 베이스 이미지 CVE-2026-42945 대응 (1.29.1 → 1.30.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build arguments
-ARG NGINX_VERSION=1.29.1-alpine
+ARG NGINX_VERSION=1.30.2-alpine
 
 # Build stage
 FROM node:18-alpine AS builder


### PR DESCRIPTION
## 배경

nginx `ngx_http_rewrite_module` 힙 버퍼 오버플로우 [CVE-2026-42945](https://nvd.nist.gov/vuln/detail/CVE-2026-42945) (NGINX Rift, CVSS 9.2, active exploitation 보고). nginx 0.6.27 ~ 1.30.0 이 영향을 받으며 stable 1.30.1 / mainline 1.31.0 에서 패치되었다(2026-05-13). 현재 `1.29.1` 은 mainline 취약 버전이다.

## 변경사항

`ARG NGINX_VERSION` 을 `1.29.1-alpine` → `1.30.2-alpine` 로 범프한다. mainline 1.31 대신 더 보수적인 stable 트랙의 최신 패치 `1.30.2` 로 수렴시킨다.

## 검증

실제 취약 트리거(`rewrite`/`if`/`set` 의 unnamed capture 로 `?` 뒤 문자열 치환)는 `nginx.conf` 에 없고 `try_files` 만 사용한다 → 런타임 노출 경로 없음. 동작 변경 없는 단순 범프이다.
